### PR TITLE
[bump] Fix broken support for PHP < 7.1

### DIFF
--- a/composer-lock.yaml
+++ b/composer-lock.yaml
@@ -6,28 +6,28 @@ _readme:
     - 'This file locks the dependencies of your project to a known state'
     - 'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies'
     - 'This file is @generated automatically'
-content-hash: d506f189cde2bad9e9b8f0731e56517d
+content-hash: 9cc683da4e147abcec3a89c451e4d339
 packages:
     -
         name: symfony/polyfill-ctype
-        version: v1.22.1
+        version: v1.19.0
         source:
             type: git
             url: 'https://github.com/symfony/polyfill-ctype.git'
-            reference: c6c942b1ac76c82448322025e084cadc56048b4e
+            reference: aed596913b70fae57be53d86faa2e9ef85a2297b
         dist:
             type: zip
-            url: 'https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e'
-            reference: c6c942b1ac76c82448322025e084cadc56048b4e
+            url: 'https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b'
+            reference: aed596913b70fae57be53d86faa2e9ef85a2297b
             shasum: ''
         require:
-            php: '>=7.1'
+            php: '>=5.3.3'
         suggest:
             ext-ctype: 'For best performance'
         type: library
         extra:
             branch-alias:
-                dev-main: 1.22-dev
+                dev-main: 1.19-dev
             thanks:
                 name: symfony/polyfill
                 url: 'https://github.com/symfony/polyfill'
@@ -54,7 +54,7 @@ packages:
             - polyfill
             - portable
         support:
-            source: 'https://github.com/symfony/polyfill-ctype/tree/v1.22.1'
+            source: 'https://github.com/symfony/polyfill-ctype/tree/v1.19.0'
         funding:
             -
                 url: 'https://symfony.com/sponsor'
@@ -65,7 +65,7 @@ packages:
             -
                 url: 'https://tidelift.com/funding/github/packagist/symfony/symfony'
                 type: tidelift
-        time: '2021-01-07T16:49:33+00:00'
+        time: '2020-10-23T09:01:57+00:00'
     -
         name: symfony/yaml
         version: v3.4.47

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "ext-json": "*",
         "symfony/yaml": "^3.4",
         "yannoff/y-a-m-l": "^1.1",
-        "yannoff/console": "^1.2"
+        "yannoff/console": "^1.2",
+        "symfony/polyfill-ctype": "<=1.19.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d506f189cde2bad9e9b8f0731e56517d",
+    "content-hash": "9cc683da4e147abcec3a89c451e4d339",
     "packages": [
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=5.3.3"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -29,7 +29,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.19-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -67,7 +67,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
             },
             "funding": [
                 {
@@ -83,7 +83,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2020-10-23T09:01:57+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.yaml
+++ b/composer.yaml
@@ -8,6 +8,7 @@ require:
     symfony/yaml: ^3.4
     yannoff/y-a-m-l: ^1.1
     yannoff/console: ^1.2
+    symfony/polyfill-ctype: '<=1.19.0'
 autoload:
     psr-4:
         Yannoff\YamlTools\: src


### PR DESCRIPTION
- Force `symfony/polyfill-ctype` version `<= 1.19.0`, since `1.20+` breaks support for `php < 7.1`

Fixes #17 