### PR TITLE
[encoder] Fix JSON last error code handling

### DIFF
--- a/src/Encoder/Json.php
+++ b/src/Encoder/Json.php
@@ -66,7 +66,7 @@ class Json extends Encoder
             throw new JsonException($e->getCode());
         }
 
-        if ($code = \json_last_error() !== JSON_ERROR_NONE) {
+        if (($code = \json_last_error()) !== JSON_ERROR_NONE) {
             throw new JsonException($code);
         }
 
@@ -93,7 +93,7 @@ class Json extends Encoder
             throw new JsonException($e->getCode());
         }
 
-        if ($code = \json_last_error() !== JSON_ERROR_NONE) {
+        if (($code = \json_last_error()) !== JSON_ERROR_NONE) {
             throw new JsonException($code);
         }
 


### PR DESCRIPTION
- FIX: return code of the `json_last_error()` call not retrieved correctly