### PR TITLE
[refactor] Simplify encoders logic

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -19,22 +19,28 @@ use Yannoff\YamlTools\Exception\EncoderException;
 abstract class Encoder
 {
     /**
-     * @param string $contents
-     * @param array  $options
+     * Transform the given string to an object or array
      *
-     * @return mixed
+     * @param string $contents The formatted text to be decoded
+     * @param array  $options  Extra decoding options
+     * @param int    $flags    Optional bitwise combination of decoding flags
+     *
+     * @return mixed The decoded object/array representation
      * @throws EncoderException
      */
-    abstract public static function decode($contents, $options = []);
+    abstract public static function decode($contents, $options = [], $flags = 0);
 
     /**
-     * @param mixed $object
-     * @param array $options
+     * Transform the given object/array to its string representation
      *
-     * @return string
+     * @param mixed $object  The object/array to be encoded
+     * @param array $options Extra encoding options
+     * @param int   $flags   Optional bitwise combination of encoding flags
+     *
+     * @return string The string representation of the encoded object/array
      * @throws EncoderException
      */
-    abstract public static function encode($object, $options = []);
+    abstract public static function encode($object, $options = [], $flags = 0);
 
 
     /**

--- a/src/Encoder/Json.php
+++ b/src/Encoder/Json.php
@@ -48,21 +48,20 @@ class Json extends Encoder
     /**
      * Decode the given JSON formatted data into an object
      *
-     * @param string $json    The input data
-     * @param array  $options An associative array of options for the decoding process:
-     *    - 'flags' : a bitwise combination of JSON_* constants (defaults to self::DEFAULT_DECODE_FLAGS)
+     * @param string $contents The input data
+     * @param array  $options  An associative array of options for the decoding process:
      *    - 'depth' : override the $depth argument passed to json_encode (defaults to self::DEFAULT_MAX_DEPTH)
+     * @param int    $flags    A bitwise combination of JSON_* constants (defaults to self::DEFAULT_DECODE_FLAGS)
      *
      * @return mixed
      * @throws JsonException
      */
-    public static function decode($json, $options = [])
+    public static function decode($contents, $options = [], $flags = self::DEFAULT_DECODE_FLAGS)
     {
         $depth = self::get($options, 'depth', self::DEFAULT_MAX_DEPTH);
-        $flags = self::get($options, 'flags', self::DEFAULT_DECODE_FLAGS);
 
         try {
-            $data = \json_decode($json, false, $depth, self::JSON_THROW_ON_ERROR | $flags);
+            $data = \json_decode($contents, false, $depth, self::JSON_THROW_ON_ERROR | $flags);
         } catch (\Exception $e) {
             throw new JsonException($e->getCode());
         }
@@ -78,16 +77,14 @@ class Json extends Encoder
      * Encode the given input object to a JSON formatted string
      *
      * @param mixed $object  The input object
-     * @param array $options An associative array of options for encoding process:
-     *    - 'flags' : a bitwise combination of JSON_* constants (defaults to self::DEFAULT_ENCODE_FLAGS)
+     * @param array $options An associative array of options for encoding process
+     * @param int   $flags   A bitwise combination of JSON_* constants (defaults to self::DEFAULT_ENCODE_FLAGS)
      *
      * @return string
      * @throws JsonException
      */
-    public static function encode($object, $options = [])
+    public static function encode($object, $options = [], $flags = self::DEFAULT_ENCODE_FLAGS)
     {
-        $flags = self::get($options, 'flags', self::DEFAULT_ENCODE_FLAGS);
-
         try {
             $json = \json_encode($object, self::JSON_THROW_ON_ERROR | $flags);
         } catch (\Exception $e) {

--- a/src/Encoder/Yaml.php
+++ b/src/Encoder/Yaml.php
@@ -52,19 +52,17 @@ class Yaml extends Encoder
     /**
      * Decode the given YAML formatted input data into an object
      *
-     * @param string $yaml    The YAML formatted contents
-     * @param array  $options An associative array of options for the decoding process:
-     *    - 'flags' : a bitwise combination of Yaml::PARSE_* constants (defaults to self::DEFAULT_DECODE_FLAGS)
+     * @param string $contents The YAML formatted contents
+     * @param array  $options  An associative array of options for the decoding process
+     * @param int    $flags    A bitwise combination of Yaml::PARSE_* constants (defaults to self::DEFAULT_DECODE_FLAGS)
      *
      * @return mixed
      * @throws YamlException
      */
-    public static function decode($yaml, $options = [])
+    public static function decode($contents, $options = [], $flags = self::DEFAULT_DECODE_FLAGS)
     {
-        $flags = self::get($options, 'flags', self::DEFAULT_DECODE_FLAGS);
-
         try {
-            return BaseYaml::parse($yaml, $flags);
+            return BaseYaml::parse($contents, $flags);
         } catch (ParseException $e) {
             throw new YamlException($e->getMessage(), $e->getCode(), $e->getPrevious());
         }
@@ -75,18 +73,17 @@ class Yaml extends Encoder
      *
      * @param mixed $object  The input object
      * @param array $options An associative array of options for the encoding process:
-     *    - 'flags'  : a bitwise combination of Yaml::DUMP_* constants (defaults to self::DEFAULT_ENCODE_FLAGS)
      *    - 'inline' : override the $inline argument passed to Yaml::dump() (defaults to self::DEFAULT_INLINE)
      *    - 'indent' : override the $indent argument passed to Yaml::dump() (defaults to self::DEFAULT_INDENT)
+     *@param int   $flags   A bitwise combination of Yaml::DUMP_* constants (defaults to self::DEFAULT_ENCODE_FLAGS)
      *
      * @return string
      * @throws YamlException
      */
-    public static function encode($object, $options = [])
+    public static function encode($object, $options = [], $flags = self::DEFAULT_ENCODE_FLAGS)
     {
         $inline = self::get($options, 'inline', self::DEFAULT_EXPAND_MAX_LEVEL);
         $indent = self::get($options, 'indent', self::DEFAULT_INDENT);
-        $flags = self::get($options, 'flags', self::DEFAULT_ENCODE_FLAGS);
 
         try {
             return BaseYaml::dump($object, $inline, $indent, $flags);


### PR DESCRIPTION
- Implement flags as plain argument in `encode`/`decode` methods