### PR TITLE
Restore support for php `5.5+` in encoders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
         strategy:
             matrix:
                 php-versions:
+                    - 5.5
                     - 5.6
                     - 7.0
                     - 7.1

--- a/composer-lock.yaml
+++ b/composer-lock.yaml
@@ -6,7 +6,7 @@ _readme:
     - 'This file locks the dependencies of your project to a known state'
     - 'Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies'
     - 'This file is @generated automatically'
-content-hash: bbb0e45340feb244228603615130c04f
+content-hash: 204d5913e2dd19a0cbb716f29478bdc4
 packages:
     -
         name: symfony/polyfill-ctype
@@ -187,7 +187,7 @@ stability-flags: []
 prefer-stable: false
 prefer-lowest: false
 platform:
-    php: '>=5.6.40'
+    php: '>=5.5'
     ext-json: '*'
 platform-dev: []
 plugin-api-version: 2.2.0

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/yannoff/yamltools",
     "type": "console-script",
     "require": {
-        "php": ">=5.6.40",
+        "php": ">=5.5",
         "ext-json": "*",
         "symfony/yaml": "^3.4",
         "yannoff/y-a-m-l": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbb0e45340feb244228603615130c04f",
+    "content-hash": "204d5913e2dd19a0cbb716f29478bdc4",
     "packages": [
         {
             "name": "symfony/polyfill-ctype",
@@ -246,7 +246,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.40",
+        "php": ">=5.5",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/composer.yaml
+++ b/composer.yaml
@@ -3,7 +3,7 @@ description: 'A command-line Swiss-Knife for YAML files'
 homepage: 'https://github.com/yannoff/yamltools'
 type: console-script
 require:
-    php: '>=5.6.40'
+    php: '>=5.5'
     ext-json: '*'
     symfony/yaml: ^3.4
     yannoff/y-a-m-l: ^1.1

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -28,7 +28,7 @@ abstract class Encoder
      * @return mixed The decoded object/array representation
      * @throws EncoderException
      */
-    abstract public static function decode($contents, $options = [], $flags = 0);
+    abstract public static function decode($contents, $options = [], $flags = null);
 
     /**
      * Transform the given object/array to its string representation
@@ -40,8 +40,21 @@ abstract class Encoder
      * @return string The string representation of the encoded object/array
      * @throws EncoderException
      */
-    abstract public static function encode($object, $options = [], $flags = 0);
+    abstract public static function encode($object, $options = [], $flags = null);
 
+    /**
+     * Return the default value for the decode() method $flag argument
+     *
+     * @return int A bitwise flags combination (zero if none)
+     */
+    abstract public static function getDefaultDecodeFlags();
+
+    /**
+     * Return the default value for the encode() method $flag argument
+     *
+     * @return int A bitwise flags combination (zero if none)
+     */
+    abstract public static function getDefaultEncodeFlags();
 
     /**
      * Extract the given queried option, falling back to the provided defaults

--- a/src/Encoder/Json.php
+++ b/src/Encoder/Json.php
@@ -32,33 +32,20 @@ class Json extends Encoder
     const DEFAULT_MAX_DEPTH = 512;
 
     /**
-     * Default bitwise flags combination for JSON decoding
-     *
-     * @var int
-     */
-    const DEFAULT_DECODE_FLAGS = JSON_FORCE_OBJECT;
-
-    /**
-     * Default bitwise flags combination for JSON encoding
-     *
-     * @var int
-     */
-    const DEFAULT_ENCODE_FLAGS = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT;
-
-    /**
      * Decode the given JSON formatted data into an object
      *
      * @param string $contents The input data
      * @param array  $options  An associative array of options for the decoding process:
-     *    - 'depth' : override the $depth argument passed to json_encode (defaults to self::DEFAULT_MAX_DEPTH)
-     * @param int    $flags    A bitwise combination of JSON_* constants (defaults to self::DEFAULT_DECODE_FLAGS)
+     *    - 'depth' : override the $depth argument passed to json_encode - defaults to self::DEFAULT_MAX_DEPTH
+     * @param int    $flags    A bitwise combination of JSON_* constants - defaults to self::getDefaultDecodeFlags()
      *
      * @return mixed
      * @throws JsonException
      */
-    public static function decode($contents, $options = [], $flags = self::DEFAULT_DECODE_FLAGS)
+    public static function decode($contents, $options = [], $flags = null)
     {
         $depth = self::get($options, 'depth', self::DEFAULT_MAX_DEPTH);
+        $flags = $flags ?: self::getDefaultDecodeFlags();
 
         try {
             $data = \json_decode($contents, false, $depth, self::JSON_THROW_ON_ERROR | $flags);
@@ -78,13 +65,15 @@ class Json extends Encoder
      *
      * @param mixed $object  The input object
      * @param array $options An associative array of options for encoding process
-     * @param int   $flags   A bitwise combination of JSON_* constants (defaults to self::DEFAULT_ENCODE_FLAGS)
+     * @param int   $flags   A bitwise combination of JSON_* constants - defaults to self::getDefaultEncodeFlags()
      *
      * @return string
      * @throws JsonException
      */
-    public static function encode($object, $options = [], $flags = self::DEFAULT_ENCODE_FLAGS)
+    public static function encode($object, $options = [], $flags = null)
     {
+        $flags = $flags ?: self::getDefaultEncodeFlags();
+
         try {
             $json = \json_encode($object, self::JSON_THROW_ON_ERROR | $flags);
         } catch (\Exception $e) {
@@ -96,5 +85,21 @@ class Json extends Encoder
         }
 
         return $json;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaultDecodeFlags()
+    {
+        return \JSON_FORCE_OBJECT;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaultEncodeFlags()
+    {
+        return \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT;
     }
 }

--- a/src/Encoder/Yaml.php
+++ b/src/Encoder/Yaml.php
@@ -34,33 +34,21 @@ class Yaml extends Encoder
      * @var int
      */
     const DEFAULT_EXPAND_MAX_LEVEL = 6;
-
-    /**
-     * Default bitwise flags combination for YAML decoding
-     *
-     * @var int
-     */
-    const DEFAULT_DECODE_FLAGS = BaseYaml::PARSE_OBJECT_FOR_MAP;
-
-    /**
-     * Default bitwise flags combination for YAML encoding
-     *
-     * @var int
-     */
-    const DEFAULT_ENCODE_FLAGS = BaseYaml::DUMP_OBJECT_AS_MAP | BaseYaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE;
-
+    
     /**
      * Decode the given YAML formatted input data into an object
      *
      * @param string $contents The YAML formatted contents
      * @param array  $options  An associative array of options for the decoding process
-     * @param int    $flags    A bitwise combination of Yaml::PARSE_* constants (defaults to self::DEFAULT_DECODE_FLAGS)
+     * @param int    $flags    A bitwise combination of Yaml::PARSE_* flags - defaults to self::getDefaultDecodeFlags()
      *
      * @return mixed
      * @throws YamlException
      */
-    public static function decode($contents, $options = [], $flags = self::DEFAULT_DECODE_FLAGS)
+    public static function decode($contents, $options = [], $flags = null)
     {
+        $flags = $flags ?: self::getDefaultDecodeFlags();
+
         try {
             return BaseYaml::parse($contents, $flags);
         } catch (ParseException $e) {
@@ -73,22 +61,39 @@ class Yaml extends Encoder
      *
      * @param mixed $object  The input object
      * @param array $options An associative array of options for the encoding process:
-     *    - 'inline' : override the $inline argument passed to Yaml::dump() (defaults to self::DEFAULT_INLINE)
-     *    - 'indent' : override the $indent argument passed to Yaml::dump() (defaults to self::DEFAULT_INDENT)
-     *@param int   $flags   A bitwise combination of Yaml::DUMP_* constants (defaults to self::DEFAULT_ENCODE_FLAGS)
+     *    - 'inline' : override the $inline argument passed to Yaml::dump() - defaults to self::DEFAULT_INLINE
+     *    - 'indent' : override the $indent argument passed to Yaml::dump() - defaults to self::DEFAULT_INDENT
+     *@param int   $flags   A bitwise combination of Yaml::DUMP_* constants - defaults to self::getDefaultEncodeFlags()
      *
      * @return string
      * @throws YamlException
      */
-    public static function encode($object, $options = [], $flags = self::DEFAULT_ENCODE_FLAGS)
+    public static function encode($object, $options = [], $flags = null)
     {
         $inline = self::get($options, 'inline', self::DEFAULT_EXPAND_MAX_LEVEL);
         $indent = self::get($options, 'indent', self::DEFAULT_INDENT);
+        $flags = $flags ?: self::getDefaultEncodeFlags();
 
         try {
             return BaseYaml::dump($object, $inline, $indent, $flags);
         } catch (DumpException $e) {
             throw new YamlException($e->getMessage(), $e->getCode(), $e->getPrevious());
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaultDecodeFlags()
+    {
+        return BaseYaml::PARSE_OBJECT_FOR_MAP;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaultEncodeFlags()
+    {
+        return BaseYaml::DUMP_OBJECT_AS_MAP | BaseYaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE;
     }
 }


### PR DESCRIPTION
- Remove bitwise flags combination constants
- Implement default flags abstract methods